### PR TITLE
fix printing of list decoration in Firefox

### DIFF
--- a/src/assets/styles/print/_index.scss
+++ b/src/assets/styles/print/_index.scss
@@ -77,6 +77,7 @@
     .entrylist::before,
     .entrylist__item::before,
     .bulletlist li::before {
+        color-adjust: exact !important;
         -webkit-print-color-adjust: exact !important;
     }
 


### PR DESCRIPTION
Firefox does not understand the vendor-prefixed version of `color-adjust`. Thus, won't print the very cool list decoration :cry:

PDFs generated with FF 77:
[Before](https://github.com/maxboeck/resume/files/4863482/print-before.pdf)
[After](https://github.com/maxboeck/resume/files/4863483/print-after.pdf)
