### PR TITLE
display social name if missing icon

### DIFF
--- a/src/assets/styles/components/_vcard.scss
+++ b/src/assets/styles/components/_vcard.scss
@@ -33,12 +33,28 @@
         align-items: center;
         margin-right: 1rem;
 
+        @include hover-focus {
+            text-decoration: none;
+            
+            .vcard__link-text {
+                text-decoration: underline;
+            }
+        }
+
         .icon {
             margin-right: 0.125em;
         }
     }
 
     @include mq(md) {
+        &__social {
+            display: flex;
+            flex-wrap: wrap;
+
+            .vcard__link {
+                margin-bottom: 0.4em; // compensate line-height
+            }
+        }
         &__link {
             display: inline-flex;
         }

--- a/src/includes/vcard.njk
+++ b/src/includes/vcard.njk
@@ -20,23 +20,23 @@
             {% endif %}
         </p> 
 
-        <div class="vard__contact p-contact">
+        <div class="vcard__contact p-contact">
             {% if author.email %}
                 <a class="vcard__link u-email" aria-label="Email" href="mailto:{{ author.email | obfuscate | safe }}">
                     {% icon "email" %}
-                    {{ author.email | obfuscate | safe }}
+                    <span class="vcard__link-text">{{ author.email | obfuscate | safe }}</span>
                 </a>
             {% endif %}
             {% if author.telephone %}
                 <a class="vcard__link p-tel" aria-label="Telephone" href="tel:{{ author.telephone | stripSpaces }}">
                     {% icon "telephone" %}
-                    {{ author.telephone }}
+                    <span class="vcard__link-text">{{ author.telephone }}</span>
                 </a>
             {% endif %}
             {% if author.website %}
                 <a class="vcard__link u-url" aria-label="Website" href="{{ author.website }}">
                     {% icon "laptop" %}
-                    {{ author.website | stripProtocol }}
+                    <span class="vcard__link-text">{{ author.website | stripProtocol }}</span>
                 </a>
             {% endif %}
 
@@ -46,7 +46,7 @@
                         <a class="vcard__link" href="{{ social.url }}" aria-label="{{ social.name }}" rel="me">
                             {%- set isSocialIcon = true -%}
                             {%- icon social.name, isSocialIcon -%}
-                            <span class="p-nickname">{{- social.user -}}</span>
+                            <span class="vcard__link-text p-nickname">{{- social.user -}}</span>
                             <span class="sr-only">on {{ social.name }}</a>
                         </a>
                     {% endfor %}

--- a/utils/shortcodes.js
+++ b/utils/shortcodes.js
@@ -14,7 +14,7 @@ module.exports = {
             'whatsapp'
         ]
         if (isSocial && !availableSocialIcons.includes(id)) {
-            return null
+            return `<span aria-hidden="true">${name}&nbsp;</span>`
         }
         return `<svg class="icon icon--${id}" role="img" aria-hidden="true" width="24" height="24">
                     <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#icon-${id}"></use>


### PR DESCRIPTION
render the name of the social media organisation instead of "undefined" when the icon is missing

Before
![rendering undefined](https://user-images.githubusercontent.com/20287693/86356705-f8824c00-bc6c-11ea-9671-b4a5a74abfb5.png)

After
![rendering the organisation name](https://user-images.githubusercontent.com/20287693/86356714-fb7d3c80-bc6c-11ea-9b82-b0f282d7ee69.png)
